### PR TITLE
test(CodeOwnersConfifg): added unit tests for overriding rules

### DIFF
--- a/__tests__/lib/CodeOwnersConfig.test.js
+++ b/__tests__/lib/CodeOwnersConfig.test.js
@@ -1,6 +1,3 @@
-const { config } = require("process");
-const { default: CodeOwner } = require("../../src/lib/CodeOwner");
-
 const CodeOwnerRuleStatement =
   require("../../src/lib/CodeOwnerRuleStatement").default;
 const CodeOwnersConfig = require("../../src/lib/CodeOwnersConfig").default;
@@ -80,6 +77,23 @@ describe("CodeOwnersConfig", () => {
         );
         expect(coc.config).toHaveProperty(["*"]);
         expect(coc.config["*"]).toBeInstanceOf(CodeOwnerRuleStatement);
+      });
+
+      it("when there are overriding rules", () => {
+        const coc = new CodeOwnersConfig(
+          {
+            "/some/directory/**": "@someone1",
+            "/some/directory/something.txt": "@someone2",
+          },
+          [],
+          ["/some/directory/something.txt"]
+        );
+
+        expect(coc.config).toHaveProperty(["/some/directory/something.txt"]);
+        expect(coc.config).not.toHaveProperty(["/some/directory/**"]);
+        expect(coc.config["/some/directory/something.txt"]).toBeInstanceOf(
+          CodeOwnerRuleStatement
+        );
       });
     });
   });


### PR DESCRIPTION
Added unit tests for CodeOwnersConfig for overrding rules, where rule in the bottom of the config is overriding the rule written above the current rule. The affected rule should be the last one and not the first one 